### PR TITLE
对于DockPaneStrip上的关闭按钮,也受到是否锁定布局的影响了

### DIFF
--- a/WinFormsUI/Docking/VS2012DarkDockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2012DarkDockPaneStrip.cs
@@ -1258,7 +1258,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 return;
 
             var indexHit = HitTest();
-            if (indexHit > -1)
+            if (indexHit > -1 && DockPane.CanClose)
                 TabCloseButtonHit(indexHit);
         }
 
@@ -1393,7 +1393,8 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private void Close_Click(object sender, EventArgs e)
         {
-            DockPane.CloseActiveContent();
+            if (DockPane.CanClose)
+                DockPane.CloseActiveContent();
         }
 
         protected internal override int HitTest(Point ptMouse)

--- a/WinFormsUI/Docking/VS2012LightDockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2012LightDockPaneStrip.cs
@@ -1258,7 +1258,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 return;
 
             var indexHit = HitTest();
-            if (indexHit > -1)
+            if (indexHit > -1 && DockPane.CanClose)
                 TabCloseButtonHit(indexHit);
         }
 
@@ -1393,7 +1393,8 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private void Close_Click(object sender, EventArgs e)
         {
-            DockPane.CloseActiveContent();
+            if (DockPane.CanClose)
+                DockPane.CloseActiveContent();
         }
 
         protected internal override int HitTest(Point ptMouse)


### PR DESCRIPTION
DockPanel中有很多种不同类型的拖放式/浮动窗口
上个版本74eo魔改的设置:锁定布局,对于需要DockPaneStrip的窗口无效(没有autohide按钮的窗口)
这次更新加入
